### PR TITLE
convert wits to preview2 syntax and added deps

### DIFF
--- a/wit/blobstore.wit
+++ b/wit/blobstore.wit
@@ -1,0 +1,27 @@
+// wasi-cloud Blobstore service definition
+default interface blobstore {
+  use pkg.container.{ container }
+  use pkg.types.{ Error, container-name, object-id, container }
+
+  // creates a new empty container
+  create-container: func(name: container-name) -> result<container,Error>
+
+  // retrieves a container by name
+  get-container: func(name: container-name) -> result<container, Error>
+
+  // deletes a container and all objects within it
+  delete-container: func(name: container-name) -> result<_, Error>
+
+  // returns true if the container exists
+  container-exists: func(name: container-name) -> result<bool, Error>
+
+  // copies (duplicates) an object, to the same or a different container.
+  // returns an error if the target container does not exist.
+  // overwrites destination object if it already existed.
+  copy-object: func(src: object-id, dest: object-id) -> result<_, Error>
+
+  // moves or renames an object, to the same or a different container
+  // returns an error if the destination container does not exist.
+  // overwrites destination object if it already existed.
+  move-object: func(src:object-id, dest: object-id) -> result<_, Error>
+}

--- a/wit/container.wit
+++ b/wit/container.wit
@@ -1,0 +1,73 @@
+// a Container is a collection of objects
+interface container {
+  use pkg.types.{ object-name, object-metadata, container-metadata, Error }
+  use pkg.data-blob.{ data-blob }
+  use io.streams.{input-stream, output-stream}
+  type read-stream = input-stream
+  type write-stream = output-stream
+
+
+  // this defines the `container` resource
+  type container = u32
+  drop-container: func(container: container)
+
+
+  // returns container name
+  name: func(container: container) -> result<string, Error>
+
+  // returns container metadata
+  info: func(container: container) -> result<container-metadata, Error>
+
+
+  // begins reading an object
+  read-object: func(container: container, name: object-name) -> result<read-stream, Error>
+
+  // creates or replaces an object.
+  write-object: func(container: container, name: object-name) -> result<write-stream, Error>
+
+  // retrieves an object or portion of an object, as a resource.
+  // Start and end offsets are inclusive.
+  // Once a data-blob resource has been created, the underlying bytes are held by the blobstore service for the lifetime
+  // of the data-blob resource, even if the object they came from is later deleted.
+  get-data: func(container: container, name: object-name, start: u64, end: u64) -> result<data-blob, Error>
+
+  // creates or replaces an object with the data blob.
+  write-data: func(container: container, name: object-name, data: data-blob) -> result<_, Error>
+
+
+  use poll.poll.{ pollable }
+  // this defines the `stream-object-names` resource which is a representation of stream<object-name>
+  type stream-object-names = u32
+  
+  drop-stream-object-names: func(stream: stream-object-names)
+  
+  // reads the next number of objects from the stream
+  //
+  // This function returns the list of objects read, and a boolean indicating if the end of the stream was reached.
+  read-stream-object-names: func(this: stream-object-names, len: u64) -> result<tuple<list<object-name>, bool>, Error>
+
+  // skip the next number of objects in the stream
+  // 
+  // This function returns the number of objects skipped, and a boolean indicating if the end of the stream was reached.
+  skip-stream-object-names: func(this: stream-object-names, num: u64) -> result<tuple<u64, bool>, Error>
+
+
+  // returns list of objects in the container. Order is undefined.
+  list-objects: func(container: container, name: object-name) -> result<stream-object-names, Error>
+
+  // deletes object.
+  // does not return error if object did not exist.
+  delete-object: func(container: container, name: object-name) -> result<_, Error>
+
+  // deletes multiple objects in the container
+  delete-objects: func(container: container, names: list<object-name>) -> result<_, Error>
+
+  // returns true if the object exists in this container
+  has-object: func(container: container, name: object-name) -> result<bool, Error>
+
+  // returns metadata for the object
+  object-info: func(container: container, name: object-name) -> result<object-metadata, Error>
+
+  // removes all objects within the container, leaving the container empty.
+  clear: func(container: container) -> result<_, Error>
+}

--- a/wit/data-blob.wit
+++ b/wit/data-blob.wit
@@ -1,0 +1,23 @@
+// A data-blob resource references a byte array. It is intended to be lightweight
+// and can be passed to other components, without the overhead of copying the underlying bytes.
+// A data-blob can be created with object::get-data(), or with the create() function below.
+interface data-blob {
+
+  use pkg.types.{ Error, object-size }
+  use io.streams.{input-stream, output-stream}
+  type read-stream = input-stream
+  type write-stream = output-stream
+  
+  // this defines the `data-blob` resource
+  type data-blob = u32
+  drop-data-blob: func(data-blob: data-blob)
+
+  // creates a new data blob
+  create: func(data-blob: data-blob) -> write-stream
+
+  // begins reading this data-blob
+  read: func(data-blob: data-blob) -> result<read-stream, Error>
+
+  // returns the total size of this data-blob
+  size: func(data-blob: data-blob) -> result<object-size, Error>
+}

--- a/wit/deps/io/streams.wit
+++ b/wit/deps/io/streams.wit
@@ -1,0 +1,213 @@
+/// WASI I/O is an I/O abstraction API which is currently focused on providing
+/// stream types.
+///
+/// In the future, the component model is expected to add built-in stream types;
+/// when it does, they are expected to subsume this API.
+default interface streams {
+    use poll.poll.{pollable}
+
+    /// An error type returned from a stream operation. Currently this
+    /// doesn't provide any additional information.
+    record stream-error {}
+
+    /// An input bytestream. In the future, this will be replaced by handle
+    /// types.
+    ///
+    /// This conceptually represents a `stream<u8, _>`. It's temporary
+    /// scaffolding until component-model's async features are ready.
+    ///
+    /// `input-stream`s are *non-blocking* to the extent practical on underlying
+    /// platforms. I/O operations always return promptly; if fewer bytes are
+    /// promptly available than requested, they return the number of bytes promptly
+    /// available, which could even be zero. To wait for data to be available,
+    /// use the `subscribe-to-input-stream` function to obtain a `pollable` which
+    /// can be polled for using `wasi_poll`.
+    ///
+    /// And at present, it is a `u32` instead of being an actual handle, until
+    /// the wit-bindgen implementation of handles and resources is ready.
+    ///
+    /// This [represents a resource](https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources).
+    type input-stream = u32
+
+    /// Read bytes from a stream.
+    ///
+    /// This function returns a list of bytes containing the data that was
+    /// read, along with a bool which, when true, indicates that the end of the
+    /// stream was reached. The returned list will contain up to `len` bytes; it
+    /// may return fewer than requested, but not more.
+    ///
+    /// Once a stream has reached the end, subsequent calls to read or
+    /// `skip` will always report end-of-stream rather than producing more
+    /// data.
+    ///
+    /// If `len` is 0, it represents a request to read 0 bytes, which should
+    /// always succeed, assuming the stream hasn't reached its end yet, and
+    /// return an empty list.
+    ///
+    /// The len here is a `u64`, but some callees may not be able to allocate
+    /// a buffer as large as that would imply.
+    /// FIXME: describe what happens if allocation fails.
+    read: func(
+        this: input-stream,
+        /// The maximum number of bytes to read
+        len: u64
+    ) -> result<tuple<list<u8>, bool>, stream-error>
+
+    /// Read bytes from a stream, with blocking.
+    ///
+    /// This is similar to `read`, except that it blocks until at least one
+    /// byte can be read.
+    blocking-read: func(
+        this: input-stream,
+        /// The maximum number of bytes to read
+        len: u64
+    ) -> result<tuple<list<u8>, bool>, stream-error>
+
+    /// Skip bytes from a stream.
+    ///
+    /// This is similar to the `read` function, but avoids copying the
+    /// bytes into the instance.
+    ///
+    /// Once a stream has reached the end, subsequent calls to read or
+    /// `skip` will always report end-of-stream rather than producing more
+    /// data.
+    ///
+    /// This function returns the number of bytes skipped, along with a bool
+    /// indicating whether the end of the stream was reached. The returned
+    /// value will be at most `len`; it may be less.
+    skip: func(
+        this: input-stream,
+        /// The maximum number of bytes to skip.
+        len: u64,
+    ) -> result<tuple<u64, bool>, stream-error>
+
+    /// Skip bytes from a stream, with blocking.
+    ///
+    /// This is similar to `skip`, except that it blocks until at least one
+    /// byte can be consumed.
+    blocking-skip: func(
+        this: input-stream,
+        /// The maximum number of bytes to skip.
+        len: u64,
+    ) -> result<tuple<u64, bool>, stream-error>
+
+    /// Create a `pollable` which will resolve once either the specified stream
+    /// has bytes available to read or the other end of the stream has been
+    /// closed.
+    subscribe-to-input-stream: func(this: input-stream) -> pollable
+
+    /// Dispose of the specified `input-stream`, after which it may no longer
+    /// be used.
+    drop-input-stream: func(this: input-stream)
+
+    /// An output bytestream. In the future, this will be replaced by handle
+    /// types.
+    ///
+    /// This conceptually represents a `stream<u8, _>`. It's temporary
+    /// scaffolding until component-model's async features are ready.
+    ///
+    /// `output-stream`s are *non-blocking* to the extent practical on
+    /// underlying platforms. Except where specified otherwise, I/O operations also
+    /// always return promptly, after the number of bytes that can be written
+    /// promptly, which could even be zero. To wait for the stream to be ready to
+    /// accept data, the `subscribe-to-output-stream` function to obtain a
+    /// `pollable` which can be polled for using `wasi_poll`.
+    ///
+    /// And at present, it is a `u32` instead of being an actual handle, until
+    /// the wit-bindgen implementation of handles and resources is ready.
+    ///
+    /// This [represents a resource](https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources).
+    type output-stream = u32
+
+    /// Write bytes to a stream.
+    ///
+    /// This function returns a `u64` indicating the number of bytes from
+    /// `buf` that were written; it may be less than the full list.
+    write: func(
+        this: output-stream,
+        /// Data to write
+        buf: list<u8>
+    ) -> result<u64, stream-error>
+
+    /// Write bytes to a stream, with blocking.
+    ///
+    /// This is similar to `write`, except that it blocks until at least one
+    /// byte can be written.
+    blocking-write: func(
+        this: output-stream,
+        /// Data to write
+        buf: list<u8>
+    ) -> result<u64, stream-error>
+
+    /// Write multiple zero bytes to a stream.
+    ///
+    /// This function returns a `u64` indicating the number of zero bytes
+    /// that were written; it may be less than `len`.
+    write-zeroes: func(
+        this: output-stream,
+        /// The number of zero bytes to write
+        len: u64
+    ) -> result<u64, stream-error>
+
+    /// Write multiple zero bytes to a stream, with blocking.
+    ///
+    /// This is similar to `write-zeroes`, except that it blocks until at least
+    /// one byte can be written.
+    blocking-write-zeroes: func(
+        this: output-stream,
+        /// The number of zero bytes to write
+        len: u64
+    ) -> result<u64, stream-error>
+
+    /// Read from one stream and write to another.
+    ///
+    /// This function returns the number of bytes transferred; it may be less
+    /// than `len`.
+    ///
+    /// Unlike other I/O functions, this function blocks until all the data
+    /// read from the input stream has been written to the output stream.
+    splice: func(
+        this: output-stream,
+        /// The stream to read from
+        src: input-stream,
+        /// The number of bytes to splice
+        len: u64,
+    ) -> result<tuple<u64, bool>, stream-error>
+
+    /// Read from one stream and write to another, with blocking.
+    ///
+    /// This is similar to `splice`, except that it blocks until at least
+    /// one byte can be read.
+    blocking-splice: func(
+        this: output-stream,
+        /// The stream to read from
+        src: input-stream,
+        /// The number of bytes to splice
+        len: u64,
+    ) -> result<tuple<u64, bool>, stream-error>
+
+    /// Forward the entire contents of an input stream to an output stream.
+    ///
+    /// This function repeatedly reads from the input stream and writes
+    /// the data to the output stream, until the end of the input stream
+    /// is reached, or an error is encountered.
+    ///
+    /// Unlike other I/O functions, this function blocks until the end
+    /// of the input stream is seen and all the data has been written to
+    /// the output stream.
+    ///
+    /// This function returns the number of bytes transferred.
+    forward: func(
+        this: output-stream,
+        /// The stream to read from
+        src: input-stream
+    ) -> result<u64, stream-error>
+
+    /// Create a `pollable` which will resolve once either the specified stream
+    /// is ready to accept bytes or the other end of the stream has been closed.
+    subscribe-to-output-stream: func(this: output-stream) -> pollable
+
+    /// Dispose of the specified `output-stream`, after which it may no longer
+    /// be used.
+    drop-output-stream: func(this: output-stream)
+}

--- a/wit/deps/poll/poll.wit
+++ b/wit/deps/poll/poll.wit
@@ -1,0 +1,39 @@
+/// A poll API intended to let users wait for I/O events on multiple handles
+/// at once.
+default interface poll {
+    /// A "pollable" handle.
+    ///
+    /// This is conceptually represents a `stream<_, _>`, or in other words,
+    /// a stream that one can wait on, repeatedly, but which does not itself
+    /// produce any data. It's temporary scaffolding until component-model's
+    /// async features are ready.
+    ///
+    /// And at present, it is a `u32` instead of being an actual handle, until
+    /// the wit-bindgen implementation of handles and resources is ready.
+    ///
+    /// `pollable` lifetimes are not automatically managed. Users must ensure
+    /// that they do not outlive the resource they reference.
+    ///
+    /// This [represents a resource](https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources).
+    type pollable = u32
+
+    /// Dispose of the specified `pollable`, after which it may no longer
+    /// be used.
+    drop-pollable: func(this: pollable)
+
+    /// Poll for completion on a set of pollables.
+    ///
+    /// The "oneoff" in the name refers to the fact that this function must do a
+    /// linear scan through the entire list of subscriptions, which may be
+    /// inefficient if the number is large and the same subscriptions are used
+    /// many times. In the future, this is expected to be obsoleted by the
+    /// component model async proposal, which will include a scalable waiting
+    /// facility.
+    ///
+    /// Note that the return type would ideally be `list<bool>`, but that would
+    /// be more difficult to polyfill given the current state of `wit-bindgen`.
+    /// See <https://github.com/bytecodealliance/preview2-prototyping/pull/11#issuecomment-1329873061>
+    /// for details.  For now, we use zero to mean "not ready" and non-zero to
+    /// mean "ready".
+    poll-oneoff: func(in: list<pollable>) -> list<u8>
+}

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -1,0 +1,45 @@
+
+// Types used by blobstore
+interface types {
+  // name of a container, a collection of objects.
+  // The container name may be any valid UTF-8 string.
+  type container-name = string
+
+  // name of an object within a container
+  // The object name may be any valid UTF-8 string.
+  type object-name = string
+
+  // TODO: define timestamp to include seconds since 
+  // Unix epoch and nanoseconds 
+  // https://github.com/WebAssembly/wasi-blob-store/issues/7
+  type timestamp = u64
+
+  // size of an object, in bytes
+  type object-size = u64
+
+  // information about a container
+  record container-metadata {
+    // the container's name
+    name: container-name,
+    // date and time container was created
+    created-at: timestamp,
+  }
+
+  // information about an object
+  record object-metadata {
+    // the object's name
+    name: object-name,
+    // the object's parent container
+    container: container-name,
+    // date and time the object was created
+    created-at: timestamp,
+    // size of the object, in bytes
+    size: object-size,
+  }
+
+  // identifier for an object that includes its container name
+  record object-id {
+    container: container-name,
+    object: object-name
+  }
+}

--- a/wit/world.wit
+++ b/wit/world.wit
@@ -1,0 +1,3 @@
+default world blob-store {
+	import blobstore: pkg.blobstore
+}


### PR DESCRIPTION
This PR converts the blob-store interfaces to wasi preview2 syntax and roughtly follows the `wasi-http` and `wasi-keyvalue` processes of conversion. It does
1. add a wit file for each interface 
2. add a blob-store world file
3. add wasi-io and wasi-poll dependencies
4. removed write-stream, read-stream and replaced them with wasi-io streams. 
5. removed `stream` syntax and use `wasi-poll` for it

FYI @stevelr