### PR TITLE
chore: update to latest WIT syntax

### DIFF
--- a/wit/blobstore.wit
+++ b/wit/blobstore.wit
@@ -1,27 +1,29 @@
+package wasi:blobstore
+
 // wasi-cloud Blobstore service definition
-default interface blobstore {
-  use pkg.container.{ container }
-  use pkg.types.{ Error, container-name, object-id, container }
+interface blobstore {
+  use container.{container}
+  use types.{error, container-name, object-id}
 
   // creates a new empty container
-  create-container: func(name: container-name) -> result<container,Error>
+  create-container: func(name: container-name) -> result<container, error>
 
   // retrieves a container by name
-  get-container: func(name: container-name) -> result<container, Error>
+  get-container: func(name: container-name) -> result<container, error>
 
   // deletes a container and all objects within it
-  delete-container: func(name: container-name) -> result<_, Error>
+  delete-container: func(name: container-name) -> result<_, error>
 
   // returns true if the container exists
-  container-exists: func(name: container-name) -> result<bool, Error>
+  container-exists: func(name: container-name) -> result<bool, error>
 
   // copies (duplicates) an object, to the same or a different container.
   // returns an error if the target container does not exist.
   // overwrites destination object if it already existed.
-  copy-object: func(src: object-id, dest: object-id) -> result<_, Error>
+  copy-object: func(src: object-id, dest: object-id) -> result<_, error>
 
   // moves or renames an object, to the same or a different container
   // returns an error if the destination container does not exist.
   // overwrites destination object if it already existed.
-  move-object: func(src:object-id, dest: object-id) -> result<_, Error>
+  move-object: func(src:object-id, dest: object-id) -> result<_, error>
 }

--- a/wit/container.wit
+++ b/wit/container.wit
@@ -1,8 +1,13 @@
+package wasi:blobstore
+
 // a Container is a collection of objects
 interface container {
-  use pkg.types.{ object-name, object-metadata, container-metadata, Error }
-  use pkg.data-blob.{ data-blob }
-  use io.streams.{input-stream, output-stream}
+  use types.{ object-name, object-metadata, container-metadata, error }
+  use data-blob.{ data-blob }
+
+  use wasi:io/streams.{input-stream, output-stream}
+  use wasi:poll/poll.{ pollable }
+
   type read-stream = input-stream
   type write-stream = output-stream
 
@@ -13,61 +18,59 @@ interface container {
 
 
   // returns container name
-  name: func(container: container) -> result<string, Error>
+  name: func(container: container) -> result<string, error>
 
   // returns container metadata
-  info: func(container: container) -> result<container-metadata, Error>
+  info: func(container: container) -> result<container-metadata, error>
 
 
   // begins reading an object
-  read-object: func(container: container, name: object-name) -> result<read-stream, Error>
+  read-object: func(container: container, name: object-name) -> result<read-stream, error>
 
   // creates or replaces an object.
-  write-object: func(container: container, name: object-name) -> result<write-stream, Error>
+  write-object: func(container: container, name: object-name) -> result<write-stream, error>
 
   // retrieves an object or portion of an object, as a resource.
   // Start and end offsets are inclusive.
   // Once a data-blob resource has been created, the underlying bytes are held by the blobstore service for the lifetime
   // of the data-blob resource, even if the object they came from is later deleted.
-  get-data: func(container: container, name: object-name, start: u64, end: u64) -> result<data-blob, Error>
+  get-data: func(container: container, name: object-name, start: u64, end: u64) -> result<data-blob, error>
 
   // creates or replaces an object with the data blob.
-  write-data: func(container: container, name: object-name, data: data-blob) -> result<_, Error>
+  write-data: func(container: container, name: object-name, data: data-blob) -> result<_, error>
 
-
-  use poll.poll.{ pollable }
   // this defines the `stream-object-names` resource which is a representation of stream<object-name>
   type stream-object-names = u32
   
-  drop-stream-object-names: func(stream: stream-object-names)
+  drop-stream-object-names: func(names: stream-object-names)
   
   // reads the next number of objects from the stream
   //
   // This function returns the list of objects read, and a boolean indicating if the end of the stream was reached.
-  read-stream-object-names: func(this: stream-object-names, len: u64) -> result<tuple<list<object-name>, bool>, Error>
+  read-stream-object-names: func(this: stream-object-names, len: u64) -> result<tuple<list<object-name>, bool>, error>
 
   // skip the next number of objects in the stream
   // 
   // This function returns the number of objects skipped, and a boolean indicating if the end of the stream was reached.
-  skip-stream-object-names: func(this: stream-object-names, num: u64) -> result<tuple<u64, bool>, Error>
+  skip-stream-object-names: func(this: stream-object-names, num: u64) -> result<tuple<u64, bool>, error>
 
 
   // returns list of objects in the container. Order is undefined.
-  list-objects: func(container: container) -> result<stream-object-names, Error>
+  list-objects: func(container: container) -> result<stream-object-names, error>
 
   // deletes object.
   // does not return error if object did not exist.
-  delete-object: func(container: container, name: object-name) -> result<_, Error>
+  delete-object: func(container: container, name: object-name) -> result<_, error>
 
   // deletes multiple objects in the container
-  delete-objects: func(container: container, names: list<object-name>) -> result<_, Error>
+  delete-objects: func(container: container, names: list<object-name>) -> result<_, error>
 
   // returns true if the object exists in this container
-  has-object: func(container: container, name: object-name) -> result<bool, Error>
+  has-object: func(container: container, name: object-name) -> result<bool, error>
 
   // returns metadata for the object
-  object-info: func(container: container, name: object-name) -> result<object-metadata, Error>
+  object-info: func(container: container, name: object-name) -> result<object-metadata, error>
 
   // removes all objects within the container, leaving the container empty.
-  clear: func(container: container) -> result<_, Error>
+  clear: func(container: container) -> result<_, error>
 }

--- a/wit/data-blob.wit
+++ b/wit/data-blob.wit
@@ -1,10 +1,13 @@
+package wasi:blobstore
+
 // A data-blob resource references a byte array. It is intended to be lightweight
 // and can be passed to other components, without the overhead of copying the underlying bytes.
 // A data-blob can be created with object::get-data(), or with the create() function below.
 interface data-blob {
+  use types.{ error, object-size }
 
-  use pkg.types.{ Error, object-size }
-  use io.streams.{input-stream, output-stream}
+  use wasi:io/streams.{input-stream, output-stream}
+
   type read-stream = input-stream
   type write-stream = output-stream
   
@@ -16,8 +19,8 @@ interface data-blob {
   create: func(data-blob: data-blob) -> write-stream
 
   // begins reading this data-blob
-  read: func(data-blob: data-blob) -> result<read-stream, Error>
+  read: func(data-blob: data-blob) -> result<read-stream, error>
 
   // returns the total size of this data-blob
-  size: func(data-blob: data-blob) -> result<object-size, Error>
+  size: func(data-blob: data-blob) -> result<object-size, error>
 }

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -1,3 +1,4 @@
+package wasi:blobstore
 
 // Types used by blobstore
 interface types {
@@ -16,6 +17,8 @@ interface types {
 
   // size of an object, in bytes
   type object-size = u64
+
+  type error = string
 
   // information about a container
   record container-metadata {

--- a/wit/world.wit
+++ b/wit/world.wit
@@ -1,3 +1,5 @@
-default world blob-store {
-	import blobstore: pkg.blobstore
+package wasi:blobstore
+
+world blob-store {
+	import blobstore
 }


### PR DESCRIPTION
- Add the package specification
- Remove unsupported `default` terms
- Rename parameter name from reserved `streams` to `names`
- Add undefined `error` type
- Ensure `error` is lowercased, since type names starting with a capital are not supported
- Fix import statements

With this change set, `wit-bindgen` can process the WIT unlike before