### PR TITLE
chore: update `wasi-io` dependency

### DIFF
--- a/wit/container.wit
+++ b/wit/container.wit
@@ -2,7 +2,7 @@ package wasi:blobstore;
 
 // a Container is a collection of objects
 interface container {
-  use wasi:io/streams.{
+  use wasi:io/streams@0.2.0-rc-2023-11-10.{
     input-stream,
     output-stream,
   };

--- a/wit/deps.lock
+++ b/wit/deps.lock
@@ -1,0 +1,4 @@
+[io]
+url = "https://github.com/WebAssembly/wasi-io/archive/v0.2.0-rc-2023-11-10.tar.gz"
+sha256 = "f2e6127b235c37c06be675a904d6acf08db953ea688d78c42892c6ad3bd194e4"
+sha512 = "32feefbc115c34bf6968cb6e9dc15e755698ee90648e5a5d84448917c36a318bd61b401195eb64330e2475e1d098bfb8dee1440d594a68e0797748762bd84ae5"

--- a/wit/deps.toml
+++ b/wit/deps.toml
@@ -1,0 +1,1 @@
+io = "https://github.com/WebAssembly/wasi-io/archive/v0.2.0-rc-2023-11-10.tar.gz"

--- a/wit/deps/io/error.wit
+++ b/wit/deps/io/error.wit
@@ -1,0 +1,34 @@
+package wasi:io@0.2.0-rc-2023-11-10;
+
+
+interface error {
+    /// A resource which represents some error information.
+    ///
+    /// The only method provided by this resource is `to-debug-string`,
+    /// which provides some human-readable information about the error.
+    ///
+    /// In the `wasi:io` package, this resource is returned through the
+    /// `wasi:io/streams/stream-error` type.
+    ///
+    /// To provide more specific error information, other interfaces may
+    /// provide functions to further "downcast" this error into more specific
+    /// error information. For example, `error`s returned in streams derived
+    /// from filesystem types to be described using the filesystem's own
+    /// error-code type, using the function
+    /// `wasi:filesystem/types/filesystem-error-code`, which takes a parameter
+    /// `borrow<error>` and returns
+    /// `option<wasi:filesystem/types/error-code>`.
+    ///
+    /// The set of functions which can "downcast" an `error` into a more
+    /// concrete type is open.
+    resource error {
+        /// Returns a string that is suitable to assist humans in debugging
+        /// this error.
+        ///
+        /// WARNING: The returned string should not be consumed mechanically!
+        /// It may change across platforms, hosts, or other implementation
+        /// details. Parsing this string is a major platform-compatibility
+        /// hazard.
+        to-debug-string: func() -> string;
+    }
+}

--- a/wit/deps/io/poll.wit
+++ b/wit/deps/io/poll.wit
@@ -1,10 +1,23 @@
-package wasi:io;
+package wasi:io@0.2.0-rc-2023-11-10;
 
 /// A poll API intended to let users wait for I/O events on multiple handles
 /// at once.
 interface poll {
-    /// A "pollable" handle.
-    resource pollable;
+    /// `pollable` epresents a single I/O event which may be ready, or not.
+    resource pollable {
+
+      /// Return the readiness of a pollable. This function never blocks.
+      ///
+      /// Returns `true` when the pollable is ready, and `false` otherwise.
+      ready: func() -> bool;
+
+      /// `block` returns immediately if the pollable is ready, and otherwise
+      /// blocks until ready.
+      ///
+      /// This function is equivalent to calling `poll.poll` on a list
+      /// containing only this pollable.
+      block: func();
+    }
 
     /// Poll for completion on a set of pollables.
     ///
@@ -24,11 +37,5 @@ interface poll {
     /// do any I/O so it doesn't fail. If any of the I/O sources identified by
     /// the pollables has an error, it is indicated by marking the source as
     /// being reaedy for I/O.
-    poll-list: func(in: list<borrow<pollable>>) -> list<u32>;
-
-    /// Poll for completion on a single pollable.
-    ///
-    /// This function is similar to `poll-list`, but operates on only a single
-    /// pollable. When it returns, the handle is ready for I/O.
-    poll-one: func(in: borrow<pollable>);
+    poll: func(in: list<borrow<pollable>>) -> list<u32>;
 }

--- a/wit/deps/io/streams.wit
+++ b/wit/deps/io/streams.wit
@@ -1,4 +1,4 @@
-package wasi:io;
+package wasi:io@0.2.0-rc-2023-11-10;
 
 /// WASI I/O is an I/O abstraction API which is currently focused on providing
 /// stream types.
@@ -6,22 +6,19 @@ package wasi:io;
 /// In the future, the component model is expected to add built-in stream types;
 /// when it does, they are expected to subsume this API.
 interface streams {
+    use error.{error};
     use poll.{pollable};
 
-    /// Streams provide a sequence of data and then end; once they end, they
-    /// no longer provide any further data.
-    ///
-    /// For example, a stream reading from a file ends when the stream reaches
-    /// the end of the file. For another example, a stream reading from a
-    /// socket ends when the socket is closed.
-    enum stream-status {
-        /// The stream is open and may produce further data.
-        open,
-        /// When reading, this indicates that the stream will not produce
-        /// further data.
-        /// When writing, this indicates that the stream will no longer be read.
-        /// Further writes are still permitted.
-        ended,
+    /// An error for input-stream and output-stream operations.
+    variant stream-error {
+        /// The last operation (a write or flush) failed before completion.
+        ///
+        /// More information is available in the `error` payload.
+        last-operation-failed(error),
+        /// The stream is closed: no more input will be accepted by the
+        /// stream. A closed output-stream will return this error on all
+        /// future operations.
+        closed
     }
 
     /// An input bytestream.
@@ -35,21 +32,20 @@ interface streams {
     resource input-stream {
         /// Perform a non-blocking read from the stream.
         ///
-        /// This function returns a list of bytes containing the data that was
-        /// read, along with a `stream-status` which, indicates whether further
-        /// reads are expected to produce data. The returned list will contain up to
-        /// `len` bytes; it may return fewer than requested, but not more. An
-        /// empty list and `stream-status:open` indicates no more data is
-        /// available at this time, and that the pollable given by `subscribe`
-        /// will be ready when more data is available.
+        /// This function returns a list of bytes containing the read data,
+        /// when successful. The returned list will contain up to `len` bytes;
+        /// it may return fewer than requested, but not more. The list is
+        /// empty when no bytes are available for reading at this time. The
+        /// pollable given by `subscribe` will be ready when more bytes are
+        /// available.
         ///
-        /// Once a stream has reached the end, subsequent calls to `read` or
-        /// `skip` will always report `stream-status:ended` rather than producing more
-        /// data.
+        /// This function fails with a `stream-error` when the operation
+        /// encounters an error, giving `last-operation-failed`, or when the
+        /// stream is closed, giving `closed`.
         ///
-        /// When the caller gives a `len` of 0, it represents a request to read 0
-        /// bytes. This read should  always succeed and return an empty list and
-        /// the current `stream-status`.
+        /// When the caller gives a `len` of 0, it represents a request to
+        /// read 0 bytes. If the stream is still open, this call should
+        /// succeed and return an empty list, or otherwise fail with `closed`.
         ///
         /// The `len` parameter is a `u64`, which could represent a list of u8 which
         /// is not possible to allocate in wasm32, or not desirable to allocate as
@@ -58,38 +54,30 @@ interface streams {
         read: func(
             /// The maximum number of bytes to read
             len: u64
-        ) -> result<tuple<list<u8>, stream-status>>;
+        ) -> result<list<u8>, stream-error>;
 
         /// Read bytes from a stream, after blocking until at least one byte can
-        /// be read. Except for blocking, identical to `read`.
+        /// be read. Except for blocking, behavior is identical to `read`.
         blocking-read: func(
             /// The maximum number of bytes to read
             len: u64
-        ) -> result<tuple<list<u8>, stream-status>>;
+        ) -> result<list<u8>, stream-error>;
 
-        /// Skip bytes from a stream.
+        /// Skip bytes from a stream. Returns number of bytes skipped.
         ///
-        /// This is similar to the `read` function, but avoids copying the
-        /// bytes into the instance.
-        ///
-        /// Once a stream has reached the end, subsequent calls to read or
-        /// `skip` will always report end-of-stream rather than producing more
-        /// data.
-        ///
-        /// This function returns the number of bytes skipped, along with a
-        /// `stream-status` indicating whether the end of the stream was
-        /// reached. The returned value will be at most `len`; it may be less.
+        /// Behaves identical to `read`, except instead of returning a list
+        /// of bytes, returns the number of bytes consumed from the stream.
         skip: func(
             /// The maximum number of bytes to skip.
             len: u64,
-        ) -> result<tuple<u64, stream-status>>;
+        ) -> result<u64, stream-error>;
 
         /// Skip bytes from a stream, after blocking until at least one byte
         /// can be skipped. Except for blocking behavior, identical to `skip`.
         blocking-skip: func(
             /// The maximum number of bytes to skip.
             len: u64,
-        ) -> result<tuple<u64, stream-status>>;
+        ) -> result<u64, stream-error>;
 
         /// Create a `pollable` which will resolve once either the specified stream
         /// has bytes available to read or the other end of the stream has been
@@ -100,18 +88,6 @@ interface streams {
         subscribe: func() -> pollable;
     }
 
-    /// An error for output-stream operations.
-    ///
-    /// Contrary to input-streams, a closed output-stream is reported using
-    /// an error.
-    enum write-error {
-        /// The last operation (a write or flush) failed before completion.
-        last-operation-failed,
-        /// The stream is closed: no more input will be accepted by the
-        /// stream. A closed output-stream will return this error on all
-        /// future operations.
-        closed
-    }
 
     /// An output bytestream.
     ///
@@ -131,7 +107,7 @@ interface streams {
         /// When this function returns 0 bytes, the `subscribe` pollable will
         /// become ready when this function will report at least 1 byte, or an
         /// error.
-        check-write: func() -> result<u64, write-error>;
+        check-write: func() -> result<u64, stream-error>;
 
         /// Perform a write. This function never blocks.
         ///
@@ -142,7 +118,7 @@ interface streams {
         /// the last call to check-write provided a permit.
         write: func(
             contents: list<u8>
-        ) -> result<_, write-error>;
+        ) -> result<_, stream-error>;
 
         /// Perform a write of up to 4096 bytes, and then flush the stream. Block
         /// until all of these operations are complete, or an error occurs.
@@ -170,7 +146,7 @@ interface streams {
         /// ```
         blocking-write-and-flush: func(
             contents: list<u8>
-        ) -> result<_, write-error>;
+        ) -> result<_, stream-error>;
 
         /// Request to flush buffered output. This function never blocks.
         ///
@@ -182,11 +158,11 @@ interface streams {
         /// writes (`check-write` will return `ok(0)`) until the flush has
         /// completed. The `subscribe` pollable will become ready when the
         /// flush has completed and the stream can accept more writes.
-        flush: func() -> result<_, write-error>;
+        flush: func() -> result<_, stream-error>;
 
         /// Request to flush buffered output, and block until flush completes
         /// and stream is ready for writing again.
-        blocking-flush: func() -> result<_, write-error>;
+        blocking-flush: func() -> result<_, stream-error>;
 
         /// Create a `pollable` which will resolve once the output-stream
         /// is ready for more writing, or an error has occured. When this
@@ -209,7 +185,7 @@ interface streams {
         write-zeroes: func(
             /// The number of zero-bytes to write
             len: u64
-        ) -> result<_, write-error>;
+        ) -> result<_, stream-error>;
 
         /// Perform a write of up to 4096 zeroes, and then flush the stream.
         /// Block until all of these operations are complete, or an error
@@ -238,48 +214,38 @@ interface streams {
         blocking-write-zeroes-and-flush: func(
             /// The number of zero-bytes to write
             len: u64
-        ) -> result<_, write-error>;
+        ) -> result<_, stream-error>;
 
         /// Read from one stream and write to another.
         ///
+        /// The behavior of splice is equivelant to:
+        /// 1. calling `check-write` on the `output-stream`
+        /// 2. calling `read` on the `input-stream` with the smaller of the
+        /// `check-write` permitted length and the `len` provided to `splice`
+        /// 3. calling `write` on the `output-stream` with that read data.
+        ///
+        /// Any error reported by the call to `check-write`, `read`, or
+        /// `write` ends the splice and reports that error.
+        ///
         /// This function returns the number of bytes transferred; it may be less
         /// than `len`.
-        ///
-        /// Unlike other I/O functions, this function blocks until all the data
-        /// read from the input stream has been written to the output stream.
         splice: func(
             /// The stream to read from
-            src: input-stream,
+            src: borrow<input-stream>,
             /// The number of bytes to splice
             len: u64,
-        ) -> result<tuple<u64, stream-status>>;
+        ) -> result<u64, stream-error>;
 
         /// Read from one stream and write to another, with blocking.
         ///
-        /// This is similar to `splice`, except that it blocks until at least
-        /// one byte can be read.
+        /// This is similar to `splice`, except that it blocks until the
+        /// `output-stream` is ready for writing, and the `input-stream`
+        /// is ready for reading, before performing the `splice`.
         blocking-splice: func(
             /// The stream to read from
-            src: input-stream,
+            src: borrow<input-stream>,
             /// The number of bytes to splice
             len: u64,
-        ) -> result<tuple<u64, stream-status>>;
-
-        /// Forward the entire contents of an input stream to an output stream.
-        ///
-        /// This function repeatedly reads from the input stream and writes
-        /// the data to the output stream, until the end of the input stream
-        /// is reached, or an error is encountered.
-        ///
-        /// Unlike other I/O functions, this function blocks until the end
-        /// of the input stream is seen and all the data has been written to
-        /// the output stream.
-        ///
-        /// This function returns the number of bytes transferred, and the status of
-        /// the output stream.
-        forward: func(
-            /// The stream to read from
-            src: input-stream
-        ) -> result<tuple<u64, stream-status>>;
+        ) -> result<u64, stream-error>;
     }
 }

--- a/wit/deps/io/world.wit
+++ b/wit/deps/io/world.wit
@@ -1,4 +1,4 @@
-package wasi:io;
+package wasi:io@0.2.0-rc-2023-11-10;
 
 world imports {
     import streams;

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -2,7 +2,7 @@ package wasi:blobstore;
 
 // Types used by blobstore
 interface types {
-  use wasi:io/streams.{input-stream, output-stream};
+  use wasi:io/streams@0.2.0-rc-2023-11-10.{input-stream, output-stream};
 
   // name of a container, a collection of objects.
   // The container name may be any valid UTF-8 string.


### PR DESCRIPTION
This updates `wasi:io` to be in sync with latest IO package used across various WASI standard packages and Wasmtime 15